### PR TITLE
zoomrecovery: bump to v1.0.11

### DIFF
--- a/Formula/zoomrecovery.rb
+++ b/Formula/zoomrecovery.rb
@@ -1,9 +1,9 @@
 class Zoomrecovery < Formula
   desc "Reset Zoom state and spoof network identity for Zoom"
   homepage "https://github.com/twinboi90/ZoomRecovery"
-  url "https://github.com/twinboi90/ZoomRecovery/archive/refs/tags/v1.1.0.a.tar.gz"
-  sha256 "553c8a4f553aa138a4847b39c1d055da71748b3d9fde9bdc7b63cc2caf339532"
-  version "1.1.0"
+  url "https://github.com/twinboi90/ZoomRecovery/archive/refs/tags/v1.0.11.tar.gz"
+  sha256 "df06d55e36d36a1d6b3d079891e16925e33f909672311d4ae541175a1c8bebb6"
+  version "1.0.11"
   
   depends_on "spoof-mac"
 


### PR DESCRIPTION
Updates the zoomrecovery formula to use the new upstream release v1.0.11.

Changes included in this update:
• Updated URL to the v1.0.11 release tarball
• Updated sha256 checksum to match the new tarball
• Updated version field to "1.0.11"

Release highlights:
• Improved compatibility for Intel-based Macs
• Expanded detection of Zoom data directories (1132 issue cleanup)
• More reliable spoof-mac detection across Apple Silicon and Intel
• Improved Wi-Fi service name handling (Wi-Fi vs AirPort)
• More defensive network interface filtering and logging