### PR TITLE
Fix: replace BAKED_VERSION with formula version string

### DIFF
--- a/Formula/zoomrecovery.rb
+++ b/Formula/zoomrecovery.rb
@@ -8,6 +8,9 @@ class Zoomrecovery < Formula
   depends_on "spoof-mac"
 
 def install
+  # Replace any existing BAKED_VERSION="..." line (placeholder or baked value)
+  # with the formula version string. Robust against both placeholder and
+  # baked-version tarballs and avoids passing a Version object to inreplace.
   inreplace "zoomrecovery" do |s|
     s.gsub!(/BAKED_VERSION=".*?"/, "BAKED_VERSION=\"#{version.to_s}\"")
   end


### PR DESCRIPTION
Problem
Homebrew installations can fail when the formula attempts a literal replacement of a placeholder or passes a Version object into inreplace. The packaged tarball may contain a baked numeric version (BAKED_VERSION="1.0.10") rather than the placeholder the formula expects, which causes inreplace to fail or raise a TypeError.

Fix
Replace any existing BAKED_VERSION="..." line inside the script with the formula version string. This is robust for both placeholder and baked-version tarballs and prevents TypeErrors by ensuring a String is used.

Code change
```ruby
inreplace "zoomrecovery" do |s|
  s.gsub!(/BAKED_VERSION=".*?"/, "BAKED_VERSION=\"#{version.to_s}\"")
end